### PR TITLE
k3 instead of e3 for show instructions shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ slice and save samples for monome norns
 ## instructions
 
 ### key/encoder controls
-access instructions for key/encoder controls within the script by pressing k1+e3
+access instructions for key/encoder controls within the script by pressing k1 + k3
 
 * All screens
   * e2: next/prev control

--- a/clipper.lua
+++ b/clipper.lua
@@ -2,7 +2,7 @@
 -- 1.1 @jaseknighter
 -- lines: llllllll.co/t/47147
 --
--- k1+e3: show instructions
+-- k1+k3: show instructions
 
 -------------------------
 -- code based on softcut studies: https://monome.org/docs/norns/softcut/


### PR DESCRIPTION
there was a small typo in the docs regarding the "show instructions" shortcut.